### PR TITLE
Target .NET 8.0.

### DIFF
--- a/src/dotnet-shift/CommandHandlers/DeployHandler.ApplicationArchive.cs
+++ b/src/dotnet-shift/CommandHandlers/DeployHandler.ApplicationArchive.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO.Pipelines;
 using System.IO.Enumeration;
 using System.IO.Compression;
-#if NET7_0
+#if NET7_0_OR_GREATER
 using System.Formats.Tar;
 #endif
 using System.Runtime.InteropServices;

--- a/src/dotnet-shift/dotnet-shift.csproj
+++ b/src/dotnet-shift/dotnet-shift.csproj
@@ -9,8 +9,7 @@
     <Copyright>Tom Deseyn</Copyright>
     <PackageId>dotnet-shift</PackageId>
     <RollForward>Major</RollForward>
-    <TargetFramework>net7.0</TargetFramework>
-    <TargetFrameworks>net6.0;$(TargetFramework)</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -30,8 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
-    <!-- Reference an older Microsoft.Build package that supports net6.0. -->
-    <PackageReference Include="Microsoft.Build" Version="17.3.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build" Version="17.8.3" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We assume the SDK can build container images, that is: .NET 8 and higher.